### PR TITLE
Add parameterized SLEEP

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ runGrive(){
     while :
     do
       grive $PARAMS
-      sleep 1
+      sleep ${SLEEP:-1}
     done
 }
 echo "Starting Grive2 Docker..."


### PR DESCRIPTION
Running a few instances of your docker container on my UNRAID server -- but CPU usage is higher than I'd like. Personally wanted a way to adjust the poll time on grive2, so I ended up introducing a SLEEP variable. If left unspecified, it defaults to 1 second.